### PR TITLE
Yhden paikan saanto

### DIFF
--- a/tarjonta-api/src/main/java/fi/vm/sade/tarjonta/service/resources/v1/dto/HakuV1RDTO.java
+++ b/tarjonta-api/src/main/java/fi/vm/sade/tarjonta/service/resources/v1/dto/HakuV1RDTO.java
@@ -117,6 +117,9 @@ public class HakuV1RDTO extends BaseV1RDTO {
     @ApiModelProperty(value = "Maksumuuri käytössä", required = false)
     private boolean maksumuuriKaytossa = false;
 
+    @ApiModelProperty(value = "Onko yhden paikan sääntö voimassa haulle ja miksi", required = true)
+    private YhdenPaikanSaanto yhdenPaikanSaanto;
+
     public void addKoodiMeta(KoodiV1RDTO koodi) {
         if (koodi == null) {
             return;
@@ -374,5 +377,42 @@ public class HakuV1RDTO extends BaseV1RDTO {
 
     private boolean isKorkeakouluHaku() {
         return StringUtils.defaultString(getKohdejoukkoUri()).startsWith("haunkohdejoukko_12#");
+    }
+
+    public YhdenPaikanSaanto  getYhdenPaikanSaanto() {
+        return YhdenPaikanSaanto.from(this);
+    }
+
+    @ApiModel(value = "Yhden paikan säännön voimassaolotieto haulle")
+    public static class YhdenPaikanSaanto {
+        @ApiModelProperty(value = "Yhden paikan sääntö voimassa", required = true)
+        public final boolean voimassa;
+        @ApiModelProperty(value = "Yhden paikan säännön perustelu", required = true)
+        public final String syy;
+
+        private static final String JATKOTUTKINTOHAKU_URI = "haunkohdejoukontarkenne_3#";
+        private static final List<String> TARKENTEET_JOILLE_YHDEN_PAIKAN_SAANTO = Collections.singletonList(JATKOTUTKINTOHAKU_URI);
+
+        public static YhdenPaikanSaanto from(HakuV1RDTO haku) {
+            if (!haku.isKorkeakouluHaku()) {
+                return new YhdenPaikanSaanto(false, "Ei korkeakouluhaku");
+            }
+            String haunKohdeJoukonTarkenne = haku.getKohdejoukonTarkenne();
+            if (StringUtils.isBlank(haunKohdeJoukonTarkenne)) {
+                return new YhdenPaikanSaanto(true, "Korkeakouluhaku ilman kohdejoukon tarkennetta");
+            }
+            for (String tarkenne : TARKENTEET_JOILLE_YHDEN_PAIKAN_SAANTO) {
+                if (haunKohdeJoukonTarkenne.startsWith(tarkenne)) {
+                    return new YhdenPaikanSaanto(true, String.format("Kohdejoukon tarkenne on '%s'", haunKohdeJoukonTarkenne));
+                }
+            }
+            return new YhdenPaikanSaanto(false, String.format("Kohdejoukon tarkenne on '%s', sääntö on voimassa tarkenteille %s",
+                haunKohdeJoukonTarkenne, TARKENTEET_JOILLE_YHDEN_PAIKAN_SAANTO));
+        }
+
+        private YhdenPaikanSaanto(boolean voimassa, String syy) {
+            this.voimassa = voimassa;
+            this.syy = syy;
+        }
     }
 }

--- a/tarjonta-service/src/test/java/fi/vm/sade/tarjonta/service/impl/resources/v1/HakuResourceImplV1Test.java
+++ b/tarjonta-service/src/test/java/fi/vm/sade/tarjonta/service/impl/resources/v1/HakuResourceImplV1Test.java
@@ -18,6 +18,7 @@ import org.mockito.Matchers;
 import java.util.Date;
 
 import static org.junit.Assert.*;
+import static org.junit.internal.matchers.StringContains.containsString;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 
@@ -82,6 +83,28 @@ public class HakuResourceImplV1Test extends TestMockBase {
         assertNotNull(result);
         assertNotNull(result.getStatus());
         assertEquals(ResultV1RDTO.ResultStatus.OK, result.getStatus());
+    }
+
+    @Test
+    public void thatHakuSingleStudyPlaceIsResolved() {
+        HakuV1RDTO hakuDTO = new HakuV1RDTO();
+
+        hakuDTO.setKohdejoukkoUri("haunkohdejoukko_10#1");
+        assertEquals(false, hakuDTO.getYhdenPaikanSaanto().voimassa);
+        assertEquals("Ei korkeakouluhaku", hakuDTO.getYhdenPaikanSaanto().syy);
+
+        hakuDTO.setKohdejoukkoUri("haunkohdejoukko_12#1");
+        hakuDTO.setKohdejoukonTarkenne("");
+        assertEquals(true, hakuDTO.getYhdenPaikanSaanto().voimassa);
+        assertEquals("Korkeakouluhaku ilman kohdejoukon tarkennetta", hakuDTO.getYhdenPaikanSaanto().syy);
+
+        hakuDTO.setKohdejoukonTarkenne("haunkohdejoukontarkenne_3#1");
+        assertEquals(true, hakuDTO.getYhdenPaikanSaanto().voimassa);
+        assertThat(hakuDTO.getYhdenPaikanSaanto().syy, containsString("Kohdejoukon tarkenne"));
+
+        hakuDTO.setKohdejoukonTarkenne("haunkohdejoukontarkenne_4#1");
+        assertEquals(false, hakuDTO.getYhdenPaikanSaanto().voimassa);
+        assertThat(hakuDTO.getYhdenPaikanSaanto().syy, containsString("Kohdejoukon tarkenne"));
     }
 
     private HakuaikaV1RDTO createHakuaika(Date start, Date end) {


### PR DESCRIPTION
Expose the flag of whether "yhden paikan sääntö" (accepting only
a single study place) holds for a given haku.
This will be used by omat sivut and later on by Valintarekisteri functionality
in valinta-tulos-service.
