### PR TITLE
Valmistavat-komotos should not be visible as entities in API

### DIFF
--- a/tarjonta-api/src/main/java/fi/vm/sade/tarjonta/shared/types/ToteutustyyppiEnum.java
+++ b/tarjonta-api/src/main/java/fi/vm/sade/tarjonta/shared/types/ToteutustyyppiEnum.java
@@ -1,5 +1,8 @@
 package fi.vm.sade.tarjonta.shared.types;
 
+import java.util.HashSet;
+import java.util.Set;
+
 public enum ToteutustyyppiEnum {
 
     AMMATILLINEN_PERUSTUTKINTO("koulutustyyppi_1"),
@@ -61,6 +64,20 @@ public enum ToteutustyyppiEnum {
             }
         }
         throw new IllegalArgumentException("Valmistava toteutustyyppi enum not found by : '" + toteutustyyppi + "'");
+    }
+
+    public static boolean isValmistavaToteutustyyppi(ToteutustyyppiEnum tyyppi) {
+        return getValmistavatToteutustyypit().contains(tyyppi);
+    }
+
+    public static Set<ToteutustyyppiEnum> getValmistavatToteutustyypit() {
+        Set<ToteutustyyppiEnum> valmistavatToteutustyypit = new HashSet<>();
+
+        valmistavatToteutustyypit.add(ERIKOISAMMATTITUTKINTO_VALMISTAVA);
+        valmistavatToteutustyypit.add(AMMATTITUTKINTO_VALMISTAVA);
+        valmistavatToteutustyypit.add(AMMATILLINEN_PERUSTUTKINTO_NAYTTOTUTKINTONA_VALMISTAVA);
+
+        return valmistavatToteutustyypit;
     }
 
 }

--- a/tarjonta-service/src/main/java/fi/vm/sade/tarjonta/dao/impl/KoulutusmoduuliToteutusDAOImpl.java
+++ b/tarjonta-service/src/main/java/fi/vm/sade/tarjonta/dao/impl/KoulutusmoduuliToteutusDAOImpl.java
@@ -44,6 +44,7 @@ import java.util.*;
 
 import static fi.vm.sade.tarjonta.dao.impl.util.QuerydslUtils.and;
 import static fi.vm.sade.tarjonta.service.resources.v1.dto.koulutus.KoodiV1RDTO.stripVersionFromKoodiUri;
+import static fi.vm.sade.tarjonta.shared.types.ToteutustyyppiEnum.*;
 
 /**
  */
@@ -103,8 +104,8 @@ public class KoulutusmoduuliToteutusDAOImpl extends AbstractJpaDAOImpl<Koulutusm
         // Sisarkoulutukset palautetaan vain ammatillisille perustutkinnoille
         Set<ToteutustyyppiEnum> siblingToteutustyyppis = new HashSet<ToteutustyyppiEnum>();
 
-        siblingToteutustyyppis.add(ToteutustyyppiEnum.AMMATILLINEN_PERUSTUTKINTO);
-        siblingToteutustyyppis.add(ToteutustyyppiEnum.AMMATILLINEN_PERUSKOULUTUS_ERITYISOPETUKSENA);
+        siblingToteutustyyppis.add(AMMATILLINEN_PERUSTUTKINTO);
+        siblingToteutustyyppis.add(AMMATILLINEN_PERUSKOULUTUS_ERITYISOPETUKSENA);
 
         if (!siblingToteutustyyppis.contains(komoto.getToteutustyyppi())) {
             return null;
@@ -359,6 +360,8 @@ public class KoulutusmoduuliToteutusDAOImpl extends AbstractJpaDAOImpl<Koulutusm
         if (lastModifiedAfter != null) {
             whereExpr = QuerydslUtils.and(whereExpr, komoto.updated.after(lastModifiedAfter));
         }
+
+        whereExpr = QuerydslUtils.and(whereExpr, komoto.toteutustyyppi.notIn(getValmistavatToteutustyypit()));
 
         JPAQuery q = from(komoto);
         if (whereExpr != null) {

--- a/tarjonta-service/src/main/java/fi/vm/sade/tarjonta/service/impl/resources/v1/KoulutusResourceImplV1.java
+++ b/tarjonta-service/src/main/java/fi/vm/sade/tarjonta/service/impl/resources/v1/KoulutusResourceImplV1.java
@@ -92,6 +92,7 @@ import static fi.vm.sade.tarjonta.service.resources.v1.dto.ErrorV1RDTO.createSys
 import static fi.vm.sade.tarjonta.service.resources.v1.dto.ErrorV1RDTO.createValidationError;
 import static fi.vm.sade.tarjonta.service.resources.v1.dto.ResultV1RDTO.ResultStatus.*;
 import static fi.vm.sade.tarjonta.service.resources.v1.dto.ResultV1RDTO.create;
+import static fi.vm.sade.tarjonta.shared.types.ToteutustyyppiEnum.isValmistavaToteutustyyppi;
 
 /**
  * @author mlyly
@@ -189,7 +190,7 @@ public class KoulutusResourceImplV1 implements KoulutusV1Resource {
 
         ResultV1RDTO<KoulutusV1RDTO> result = new ResultV1RDTO<KoulutusV1RDTO>();
         final KoulutusmoduuliToteutus komoto = this.koulutusmoduuliToteutusDAO.findKomotoByOid(komotoOid);
-        if (komoto == null) {
+        if (komoto == null || isValmistavaToteutustyyppi(komoto.getToteutustyyppi())) {
             result.setStatus(NOT_FOUND);
             return result;
         }


### PR DESCRIPTION
Valmistavat komotos are always children to other komotos and
therefore they should not be accessed directly in the API.

Other integrations that depend on Tarjonta have reported this as a problem, as valmistavat koulutukset have appearead for example in the lastmodified-resource. However, the valmistavat kolutukset are not meant to be accessed and previously they have returned internal server error when accessing them. Therefore it has been impossible to distinguish between a "real" broken komoto vs. a valmistava komoto.
