### PR TITLE
BUG-986 Hibernate looses komo reference in setSisaltyyKoulutuksiin

### DIFF
--- a/tarjonta-service/src/main/java/fi/vm/sade/tarjonta/service/impl/resources/v1/KoulutusResourceImplV1.java
+++ b/tarjonta-service/src/main/java/fi/vm/sade/tarjonta/service/impl/resources/v1/KoulutusResourceImplV1.java
@@ -712,8 +712,9 @@ public class KoulutusResourceImplV1 implements KoulutusV1Resource {
     }
 
     private KoulutusmoduuliToteutus updateTutkintoonjohtamaton(KoulutusmoduuliToteutus komoto, final TutkintoonJohtamatonKoulutusV1RDTO dto) {
-        convertToEntity.setSisaltyyKoulutuksiin(komoto, dto);
-        return convertToEntity.convert(dto, contextDataService.getCurrentUserOid(), null, null);
+        KoulutusmoduuliToteutus updatedKomoto = convertToEntity.convert(dto, contextDataService.getCurrentUserOid(), null, null);
+        convertToEntity.setSisaltyyKoulutuksiin(updatedKomoto, dto);
+        return updatedKomoto;
     }
 
     private KoulutusmoduuliToteutus insertKoulutusKorkeakoulu(final KoulutusKorkeakouluV1RDTO dto) {


### PR DESCRIPTION
This causes komo modifications to disappears (such as "tavoitteet"-text modifications).
Fix by calling setSisaltyyKoulutuksiin only after komo is already modified.
