### PR TITLE
BUG-1730 - Keep yhteystiedot if "use organization's address" is selected

### DIFF
--- a/tarjonta-app-angular/app/partials/hakukohde/hakukohdeParentController.js
+++ b/tarjonta-app-angular/app/partials/hakukohde/hakukohdeParentController.js
@@ -1375,12 +1375,6 @@ app.controller('HakukohdeParentController', [
                     $scope.getHakuByOid($scope.model.hakukohde.hakuOid),
                     $scope.hakukohdex.result);
                 if (errors.length === 0 && $scope.editHakukohdeForm.$valid) {
-
-                    if ($scope.model.yhteystiedotKaytaOrganisaatioOsoitetta) {
-                        // Tyhjennä taulukko säilyttäen alkuperäinen referenssi
-                        $scope.model.hakukohde.yhteystiedot.splice(0, $scope.model.hakukohde.yhteystiedot.length);
-                    }
-
                     updateTila(tila);
                     $scope.model.hakukohde.modifiedBy = AuthService.getUserOid();
                     $scope.removeEmptyKuvaukses();


### PR DESCRIPTION
Previous implementation of web app was sending an empty yhteystiedot array if
hakukohde was set to use its organization's hakuosoite. Koulutusinformaatio
module was not able to figure out the right organization's address because
it does not have the information about organizational hierarchy.

With this change, tarjonta will always send the hakuosoite, even if
it is a organization's osoite, so that koulutusinformatio has the
correct data to show.