### PR TITLE
Bug 1846: Tarjonnan organisaatioissa ei näy lakkautetut organisaatiot

### DIFF
--- a/tarjonta-app-angular/app/partials/search/searchParameters.js
+++ b/tarjonta-app-angular/app/partials/search/searchParameters.js
@@ -102,6 +102,7 @@ angular.module('search.hakutulokset.searchparameters', [])
                 'searchStr': '',
                 'organisaatiotyyppi': '',
                 'oppilaitostyyppi': undefined,
+                'aktiiviset': true,
                 'lakkautetut': false,
                 'suunnitellut': false,
                 'skipparents': true

--- a/tarjonta-app-angular/app/partials/search/searchParameters.js
+++ b/tarjonta-app-angular/app/partials/search/searchParameters.js
@@ -100,8 +100,6 @@ angular.module('search.hakutulokset.searchparameters', [])
         function getDefaultHakuehdot() {
             return {
                 'searchStr': '',
-                'organisaatiotyyppi': '',
-                'oppilaitostyyppi': undefined,
                 'aktiiviset': true,
                 'lakkautetut': false,
                 'suunnitellut': false,

--- a/tarjonta-app-angular/app/resources/tarjonta-app-oph_properties.js
+++ b/tarjonta-app-angular/app/resources/tarjonta-app-oph_properties.js
@@ -75,7 +75,7 @@ window.urls.addProperties( {
     "koodisto-service.koodiInKoodisto":"/koodisto-service/rest/json/$1/koodi/$2",
     "koodisto-service.search":"/koodisto-service/rest/json/searchKoodis",
 
-    "organisaatio-service.search":"/organisaatio-service/rest/organisaatio/hae",
+    "organisaatio-service.search":"/organisaatio-service/rest/organisaatio/v2/hae",
     "organisaatio-service.ryhmat":"/organisaatio-service/rest/organisaatio/v2/ryhmat",
     "organisaatio-service.byOid":"/organisaatio-service/rest/organisaatio/$1",
     "organisaatio-service.parentOids":"/organisaatio-service/rest/organisaatio/$1/parentoids",

--- a/tarjonta-app-angular/app/resources/tarjonta-app-oph_properties.js
+++ b/tarjonta-app-angular/app/resources/tarjonta-app-oph_properties.js
@@ -75,7 +75,7 @@ window.urls.addProperties( {
     "koodisto-service.koodiInKoodisto":"/koodisto-service/rest/json/$1/koodi/$2",
     "koodisto-service.search":"/koodisto-service/rest/json/searchKoodis",
 
-    "organisaatio-service.search":"/organisaatio-service/rest/organisaatio/v2/hae",
+    "organisaatio-service.search":"/organisaatio-service/rest/organisaatio/v2/hierarkia/hae",
     "organisaatio-service.ryhmat":"/organisaatio-service/rest/organisaatio/v2/ryhmat",
     "organisaatio-service.byOid":"/organisaatio-service/rest/organisaatio/$1",
     "organisaatio-service.parentOids":"/organisaatio-service/rest/organisaatio/$1/parentoids",


### PR DESCRIPTION
Siirrytty käyttämään tuoretta rajapintaversiota. Aktiiviset organisaatiot haetaan oletuksena, ja kälivalintojen mukaan myös lakkautetut ja/tai suunnitellut.