### PR TITLE
BUG-1846: Korjaa organisaatiovalinnat

### DIFF
--- a/tarjonta-app-angular/app/js/shared/CommonUtilService.js
+++ b/tarjonta-app-angular/app/js/shared/CommonUtilService.js
@@ -58,6 +58,8 @@ app.service('CommonUtilService', function($resource, $log, $q, Config, Organisaa
         else if (organisaatio.organisaatiotyypit.indexOf('TOIMIPISTE') != -1) {
             var findOppilaitosFromParents = function(oid) {
                 OrganisaatioService.etsi({
+                    aktiiviset: true,
+                    suunnitellut: true,
                     oidRestrictionList: oid
                 }).then(function(vastaus) {
                     if (vastaus.organisaatiot[0].organisaatiotyypit.indexOf('TOIMIPISTE') !== -1) {

--- a/tarjonta-app-angular/app/js/shared/organisaatio.js
+++ b/tarjonta-app-angular/app/js/shared/organisaatio.js
@@ -113,6 +113,8 @@ angular.module('Organisaatio', [
             var deferred = $q.defer();
             // hae org (ja sen alapuoliset)
             etsi({
+                aktiiviset: true,
+                suunnitellut: true,
                 oidRestrictionList: organisaatioOid
             }).then(function(data) {
                 var organisaatio = data.organisaatiot[0];
@@ -295,6 +297,8 @@ angular.module('Organisaatio', [
                 var deferred = $q.defer();
 
                 etsi({
+                    aktiiviset: true,
+                    suunnitellut: true,
                     oidRestrictionList: oidRestrictionList || AuthService.getOrganisations()
                 }).then(function(response) {
                     var organizationMap = {};

--- a/tarjonta-app-angular/app/partials/haku/edit/select-organisations-dialog.js
+++ b/tarjonta-app-angular/app/partials/haku/edit/select-organisations-dialog.js
@@ -44,6 +44,8 @@ app.controller('HakuEditSelectOrganisationsController', [
         promises.push(deferred.promise);
         // haetaan organisaatihierarkia joka valittuna kälissä tai jos mitään ei ole valittuna organisaatiot joihin käyttöoikeus
         OrganisaatioService.etsi({
+            aktiiviset: true,
+            suunnitellut: true,
             oidRestrictionList: AuthService.getOrganisations()
         }).then(function(vastaus) {
             $log.info('  X asetetaan org hakutulos modeliin.');

--- a/tarjonta-app-angular/app/partials/hakukohde/hakukohdeParentController.js
+++ b/tarjonta-app-angular/app/partials/hakukohde/hakukohdeParentController.js
@@ -380,6 +380,8 @@ app.controller('HakukohdeParentController', [
         };
         $scope.haeTarjoajaOppilaitosTyypit = function() {
             OrganisaatioService.etsi({
+                aktiiviset: true,
+                suunnitellut: true,
                 oidRestrictionList: $scope.model.hakukohde.tarjoajaOids
             }).then(function(data) {
                 getOppilaitosTyyppis(data.organisaatiot);

--- a/tarjonta-app-angular/app/partials/koulutus/luo-koulutus-dialogi.js
+++ b/tarjonta-app-angular/app/partials/koulutus/luo-koulutus-dialogi.js
@@ -111,6 +111,8 @@ app.controller('LuoKoulutusDialogiController', function($location, $q, $scope, K
     $scope.sallitutKoulutustyypit = $scope.sallitutKoulutustyypit || [];
     // haetaan organisaatihierarkia joka valittuna kälissä tai jos mitään ei ole valittuna organisaatiot joihin käyttöoikeus
     OrganisaatioService.etsi({
+        aktiiviset: true,
+        suunnitellut: true,
         oidRestrictionList: $scope.luoKoulutusDialogOrg || AuthService.getOrganisations()
     }).then(function(vastaus) {
         $scope.lkorganisaatiot = vastaus.organisaatiot;

--- a/tarjonta-app-angular/app/partials/search/controllers.js
+++ b/tarjonta-app-angular/app/partials/search/controllers.js
@@ -72,6 +72,8 @@ angular.module('app.search.controllers', [
         selectOrg = getDefaultOrg();
         if (orgs.indexOf(OPH_ORG_OID) == -1) {
             OrganisaatioService.etsi({
+                aktiiviset: true,
+                suunnitellut: true,
                 oidRestrictionList: orgs
             }).then(function(vastaus) {
                 $scope.$root.tulos = vastaus.organisaatiot;

--- a/tarjonta-app-angular/app/partials/valintaperustekuvaus/search/valintaperustesearchcontroller.js
+++ b/tarjonta-app-angular/app/partials/valintaperustekuvaus/search/valintaperustesearchcontroller.js
@@ -41,6 +41,8 @@ app.controller('ValintaperusteSearchController', function($scope, $rootScope, $r
             $log.info('USER IS NOT OPH, GETTING ORGANIZATIONS....');
             $log.info('USER ORGANIZATIONS : ', AuthService.getOrganisations());
             OrganisaatioService.etsi({
+                aktiiviset: true,
+                suunnitellut: true,
                 oidRestrictionList: AuthService.getOrganisations()
             }).then(function(data) {
                 getOppilaitosTyyppis(data.organisaatiot);


### PR DESCRIPTION
Liittyy muutokseen 45527363fc35155da04401dc2b3fc4eef7ad4abd

Organisaatiopalvelun /v2/hierarkia käyttää oletuksena hakuehtoja
aktiiviset=false ja suunnitellut=false (v1-rajapinnan oletus true).