### PR TITLE
VTKU-33: Remove duplicate HakukohdePerustieto

### DIFF
--- a/tarjonta-service/src/main/java/fi/vm/sade/tarjonta/service/impl/resources/v1/HakuResourceImplV1.java
+++ b/tarjonta-service/src/main/java/fi/vm/sade/tarjonta/service/impl/resources/v1/HakuResourceImplV1.java
@@ -988,7 +988,13 @@ public class HakuResourceImplV1 implements HakuV1Resource {
         HakukohteetVastaus hakukohteetRyhmarajauksella = hakukohdeSearchService.haeHakukohteet(hakukohteetKysely);
         LOG.info("Löytyi vielä " + hakukohteetRyhmarajauksella.getHitCount() + " tulosta ryhmärajauksella.");
         Set<HakukohdePerustieto> kaikkiTulokset = new HashSet<>(hakukohteetTarjoajarajauksella.getHakukohteet());
-        kaikkiTulokset.addAll(hakukohteetRyhmarajauksella.getHakukohteet());
+        hakukohteetRyhmarajauksella.getHakukohteet().forEach(hakukohdeRyhmanPerusteella -> {
+            if (kaikkiTulokset.stream().anyMatch(h -> h.getOid().equals(hakukohdeRyhmanPerusteella.getOid()))) {
+                LOG.debug("Skipataan hakukohde " + hakukohdeRyhmanPerusteella.getOid() + " , jonka oidilla on jo lisätty hakukohde tarjoajarajauksella.");
+            } else {
+                kaikkiTulokset.add(hakukohdeRyhmanPerusteella);
+            }
+        });
         return kaikkiTulokset;
     }
 


### PR DESCRIPTION
Unfortunately they do not have equals and hashCode which
would differentiate them by oid, and at this time of the
lifecycle of Tarjonta it might not be sensible to change
the fact.