### PR TITLE
OY-328  aloituspaikat kielistys poisto

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <httpcore.version>4.4.9</httpcore.version>
     <httpmime.version>4.3.1</httpmime.version>
     <jackson-asl.version>1.9.13</jackson-asl.version>
-    <jackson.version>2.8.1</jackson.version>
+    <jackson.version>2.10.1</jackson.version>
     <java-cas.version>0.5.0-SNAPSHOT</java-cas.version>
     <java-utils.version>0.3.0-SNAPSHOT</java-utils.version>
     <java-utils.httpclient.version>0.3.0-SNAPSHOT</java-utils.httpclient.version>

--- a/tarjonta-app-angular/package.json
+++ b/tarjonta-app-angular/package.json
@@ -8,7 +8,7 @@
   "devDependencies": {
     "async": "^0.9.0",
     "del": "^1.1.1",
-    "express": "3.4.4",
+    "express": "4.17.1",
     "fb-flo": "^0.3.1",
     "gulp": "^3.8.11",
     "gulp-concat": "^2.5.2",

--- a/tarjonta-app-angular/package.json
+++ b/tarjonta-app-angular/package.json
@@ -26,7 +26,7 @@
     "lodash": "^3.5.0",
     "phantomjs": "~2.1.7",
     "q": "^1.1.1",
-    "request": "2.34.0",
+    "request": "2.88.0",
     "run-sequence": "^1.0.2"
   },
   "dependencies": {

--- a/tarjonta-service/src/main/java/fi/vm/sade/tarjonta/service/impl/resources/v1/ConverterV1.java
+++ b/tarjonta-service/src/main/java/fi/vm/sade/tarjonta/service/impl/resources/v1/ConverterV1.java
@@ -1071,6 +1071,10 @@ public class ConverterV1 {
         hakukohde.setOid(hakukohdeRDTO.getOid());
         hakukohde.setAloituspaikatLkm(hakukohdeRDTO.getAloituspaikatLkm());
 
+        if (hakukohdeRDTO.getAloituspaikatKuvaukset() != null && !hakukohdeRDTO.getAloituspaikatKuvaukset().isEmpty()) {
+            LOG.warn("field `aloituspaikatKuvaukset` was given a value but is deprecated and will not be saved.");
+        }
+
         hakukohde.setHakuaikaAlkuPvm(hakukohdeRDTO.getHakuaikaAlkuPvm());
         hakukohde.setHakuaikaLoppuPvm(hakukohdeRDTO.getHakuaikaLoppuPvm());
 

--- a/tarjonta-service/src/main/java/fi/vm/sade/tarjonta/service/impl/resources/v1/ConverterV1.java
+++ b/tarjonta-service/src/main/java/fi/vm/sade/tarjonta/service/impl/resources/v1/ConverterV1.java
@@ -1070,7 +1070,7 @@ public class ConverterV1 {
         Hakukohde hakukohde = new Hakukohde();
         hakukohde.setOid(hakukohdeRDTO.getOid());
         hakukohde.setAloituspaikatLkm(hakukohdeRDTO.getAloituspaikatLkm());
-        hakukohde.setAloituspaikatKuvaus(convertMapToMonikielinenTeksti(hakukohdeRDTO.getAloituspaikatKuvaukset()));
+
         hakukohde.setHakuaikaAlkuPvm(hakukohdeRDTO.getHakuaikaAlkuPvm());
         hakukohde.setHakuaikaLoppuPvm(hakukohdeRDTO.getHakuaikaLoppuPvm());
 

--- a/tarjonta-service/src/test/java/fi/vm/sade/tarjonta/service/impl/resources/v1/ConverterV1Test.java
+++ b/tarjonta-service/src/test/java/fi/vm/sade/tarjonta/service/impl/resources/v1/ConverterV1Test.java
@@ -177,6 +177,21 @@ public class ConverterV1Test extends TestMockBase {
     }
 
     @Test
+    public void thatAloituspaikatKuvauksetIsNotConverted() {
+        HakukohdeV1RDTO hakukohdeDTO = getHakukohdeDTO();
+        Map<String,String> aloituspaikatKuvaukset = new HashMap<String,String>();
+        aloituspaikatKuvaukset.put("fi", "kymmenen");
+        aloituspaikatKuvaukset.put("sv", "tio");
+        hakukohdeDTO.setAloituspaikatKuvaukset(aloituspaikatKuvaukset);
+        String oid = "9.8.7";
+        hakukohdeDTO.setOid(oid);
+
+        Hakukohde hakukohde = converter.toHakukohde(hakukohdeDTO);
+        assertEquals(oid, hakukohde.getOid());
+        assertNull(hakukohde.getAloituspaikatKuvaus());
+    }
+
+    @Test
     public void thatValintakokeetAreConvertedToDTO() {
         when(tarjontaKoodistoHelper.getHakukelpoisuusvaatimusrymaUriForHakukohde(anyString())).thenReturn(null);
 


### PR DESCRIPTION
Ei tallenneta rajapinnasta tulevaa getAloituspaikatKuvaukset -kenttää hakukohteita luodessa tai päivittäessä. Logitetaan jos kentälle oli annettu arvo.

Samalla mukana dependabotin ehdottamat riippuvuuspäivitykset.