### PR TITLE
Pidempi HTTP-timeout

### DIFF
--- a/src/main/resources/oph-configuration/tarjonta.properties.template
+++ b/src/main/resources/oph-configuration/tarjonta.properties.template
@@ -84,6 +84,8 @@ tarjonta-service.postgresql.maxwait={{host_postgresql_tarjonta_max_wait}}
 tarjonta-service.postgresql.maxlifetimemillis=60000
 
 tarjonta-service.organisaatiocache.refresh-interval-seconds={{tarjonta_organisaatiocache_refresh_interval_seconds | default("60")}}
+tarjonta-service.httpclient.timeout.millis={{tarjonta_httpclient_timeout_millis | default('60000')}}
+tarjonta-service.httpclient.keepalive.seconds={{tarjonta_httpclient_keepalive_seconds | default('60')}}
 
 invalid.koulutus.report.recipient={{tarjonta_invalid_koulutus_report_recipient}}
 

--- a/tarjonta-shared/src/main/java/fi/vm/sade/tarjonta/shared/HttpClientConfiguration.java
+++ b/tarjonta-shared/src/main/java/fi/vm/sade/tarjonta/shared/HttpClientConfiguration.java
@@ -3,6 +3,7 @@ package fi.vm.sade.tarjonta.shared;
 import fi.vm.sade.javautils.httpclient.OphHttpClient;
 import fi.vm.sade.javautils.httpclient.apache.ApacheOphHttpClient;
 import fi.vm.sade.properties.OphProperties;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -13,8 +14,9 @@ public class HttpClientConfiguration {
     public static final String CSRF_VALUE = "CSRF";
 
     @Bean
-    public OphHttpClient httpClient(OphProperties properties) {
-        return ApacheOphHttpClient.createDefaultOphClient(CALLER_ID, properties);
+    public OphHttpClient httpClient(OphProperties properties,
+                                    @Value("${tarjonta-service.httpclient.timeout.millis:59999}") int timeoutMs,
+                                    @Value("${tarjonta-service.httpclient.keepalive.seconds:59}") int connectionTimeToLiveSec) {
+        return ApacheOphHttpClient.createDefaultOphClient(CALLER_ID, properties, timeoutMs, connectionTimeToLiveSec);
     }
-
 }

--- a/tarjonta-shared/src/main/java/fi/vm/sade/tarjonta/shared/OrganisaatioService.java
+++ b/tarjonta-shared/src/main/java/fi/vm/sade/tarjonta/shared/OrganisaatioService.java
@@ -158,7 +158,7 @@ public class OrganisaatioService {
         } catch (ExecutionException e) {
             final String msg = "Getting organization from Guava cache failed. Org oid: " + oid;
             LOG.error(msg, e);
-            throw new RuntimeException(msg);
+            throw new RuntimeException(msg, e);
         }
     }
 
@@ -168,7 +168,7 @@ public class OrganisaatioService {
         } catch (ExecutionException e) {
             final String msg = "Getting organization from Guava cache failed for hae API. Org oid: " + oid;
             LOG.error(msg, e);
-            throw new RuntimeException(msg);
+            throw new RuntimeException(msg, e);
         }
     }
 
@@ -178,7 +178,7 @@ public class OrganisaatioService {
         } catch (ExecutionException e) {
             final String msg = "Getting organization from Guava cache failed for hae API. Org oid: " + oid;
             LOG.error(msg, e);
-            throw new RuntimeException(msg);
+            throw new RuntimeException(msg, e);
         }
     }
     private OrganisaatioResultDTO fetchOrganisationWithHaeAPI(String oid) {
@@ -188,7 +188,7 @@ public class OrganisaatioService {
         } catch (Exception e) {
             final String msg = "Could not fetch organization with oid " + oid;
             LOG.error(msg, e);
-            throw new RuntimeException(msg);
+            throw new RuntimeException(msg, e);
         }
     }
 
@@ -199,7 +199,7 @@ public class OrganisaatioService {
         } catch (Exception e) {
             final String msg = "Could not fetch all organizations";
             LOG.error(msg, e);
-            throw new RuntimeException(msg);
+            throw new RuntimeException(msg, e);
         }
     }
 
@@ -210,7 +210,7 @@ public class OrganisaatioService {
         } catch (Exception e) {
             final String msg = "Could not fetch organization with oid " + oid;
             LOG.error(msg, e);
-            throw new RuntimeException(msg);
+            throw new RuntimeException(msg, e);
         }
     }
 
@@ -222,7 +222,7 @@ public class OrganisaatioService {
         } catch (Exception e) {
             final String msg = "Could not fetch organization with oid " + oid;
             LOG.error(msg, e);
-            throw new RuntimeException(msg);
+            throw new RuntimeException(msg, e);
         }
     }
 
@@ -239,7 +239,7 @@ public class OrganisaatioService {
         } catch (Exception e) {
             final String msg = "Could not fetch child oids for organization with oid " + oid;
             LOG.error(msg, e);
-            throw new RuntimeException(msg);
+            throw new RuntimeException(msg, e);
         }
     }
 


### PR DESCRIPTION
Kasvata HTTP-pyyntöjen timeout 10 => 60 s

Timeout-arvo on nyt myös konfiguroitavissa.
Ja organisaatiopalvelu-pyyntöjen ongelmista pitäisi nyt tulla enemmän tietoa logille.
    
Organisaatiopalvelun cachen päivittäminen kestää usein pidempään kuin 10 s ainakin QA-ympäristössä:
    
    {"timestamp": "2020-04-08T11:52:05.286+0300", "responseCode": "200", "request": "GET /organisaatio-service/rest/organisaatio/v2/hierarkia/hae?aktiiviset=true&suunnitellut=true&lakkautetut=true HTTP/1.1", "responseTime": "28918", "requestMethod": "GET", "service": "organisaatio", "environment": "pallero", "customer": "OPH", "user-agent": "Apache-HttpClient/4.5.2 (Java/1.8.0_242)", "caller-id": "1.2.246.562.10.00000000001.tarjonta", "clientSubSystemCode": "-", "x-forwarded-for": "54.76.73.203, 54.76.73.203, 10.20.90.237", "x-real-ip": "54.76.73.203", "remote-ip": "10.20.65.25", "session": "-", "response-size": "-", "referer": "-", "opintopolku-api-key": "-"}
    {"timestamp": "2020-04-08T11:52:10.694+0300", "responseCode": "200", "request": "GET /organisaatio-service/rest/organisaatio/v2/hierarkia/hae?aktiiviset=true&suunnitellut=true&lakkautetut=true HTTP/1.1", "responseTime": "25132", "requestMethod": "GET", "service": "organisaatio", "environment": "pallero", "customer": "OPH", "user-agent": "Apache-HttpClient/4.5.2 (Java/1.8.0_242)", "caller-id": "1.2.246.562.10.00000000001.tarjonta", "clientSubSystemCode": "-", "x-forwarded-for": "54.76.73.203, 54.76.73.203, 10.20.97.195", "x-real-ip": "54.76.73.203", "remote-ip": "10.20.65.25", "session": "-", "response-size": "-", "referer": "-", "opintopolku-api-key": "-"}


